### PR TITLE
Nm/timing optimization

### DIFF
--- a/aspnet-core/src/Sg.ClockifyIt.Domain/ClockifyBackgroundWorker.cs
+++ b/aspnet-core/src/Sg.ClockifyIt.Domain/ClockifyBackgroundWorker.cs
@@ -31,6 +31,9 @@ namespace Sg.ClockifyIt
 
             await manager.SyncAsync();
 
+            GC.Collect(2, GCCollectionMode.Forced, true);
+            GC.WaitForPendingFinalizers();
+
             if (Options.Once)
             {
                 // This doesn't seem to do the trick


### PR DESCRIPTION
- Attempt to reduce the memory consumption over long periods
  - the framework doesn't aggresively frees memory since it uses the server gc mode
- fixed minor timing issues
  -  using local time instead of utc for fetching time entries
  - properly filtering not ended records

Fixes #12